### PR TITLE
add numerical ratings for tv episodes

### DIFF
--- a/720p/MyVideoNav.xml
+++ b/720p/MyVideoNav.xml
@@ -216,7 +216,7 @@
 				<visible>Container.Content(episodes)</visible>
 			</control>
 			<control type="radiobutton" id="109">
-                 <description>Numerical Raiting</description>
+                 <description>Numerical Rating</description>
                 <width>280</width>
 				<textoffsetx>10</textoffsetx>
                 <align>left</align>
@@ -224,10 +224,10 @@
 				<font>List_Left_Menu</font>
                 <onclick>Skin.ToggleSetting(ShowNumericalRatingForTvShows)</onclick>
                 <selected>Skin.HasSetting(ShowNumericalRatingForTvShows)</selected>
-				<visible>Container.Content(tvshows)</visible>
+				<visible>Container.Content(tvshows) | Container.Content(episodes)</visible>
 			</control>
 			<control type="radiobutton" id="110">
-                 <description>Numerical Raiting</description>
+                 <description>Numerical Rating</description>
                 <width>280</width>
 				<textoffsetx>10</textoffsetx>
                 <align>left</align>

--- a/720p/Viewtype_Episodes_List.xml
+++ b/720p/Viewtype_Episodes_List.xml
@@ -477,6 +477,18 @@
 					<height>25</height>
 					<texture>$VAR[ItemStarRating]</texture>
 					<aspectratio scalediffuse="false">keep</aspectratio>
+					<visible>!Skin.HasSetting(ShowNumericalRatingForTvShows)</visible>
+				</control>
+				<control type="label">
+				  <left>825</left>
+				  <top>565</top>
+				  <width>200</width>
+				  <height>25</height>
+				  <textcolor>Accent</textcolor>
+				  <align>left</align>
+				  <font>Panel_Description_Footer</font>
+				  <label>$INFO[ListItem.Rating,[COLOR=white]IMDB [/COLOR]]</label>
+				  <visible>Skin.HasSetting(ShowNumericalRatingForTvShows)</visible>
 				</control>
 				<control type="label">
 					<left>1060</left>


### PR DESCRIPTION
This pull request adds the possibility to have numerical ratings from imdb, for both the tv show and its episodes when using the List Info view.